### PR TITLE
Adding missing final statements

### DIFF
--- a/src/codeu/chat/server/Server.java
+++ b/src/codeu/chat/server/Server.java
@@ -56,7 +56,7 @@ public final class Server {
   private final Relay relay;
   private Uuid lastSeen = Uuids.NULL;
 
-  public Server(Uuid id, byte[] secret, Relay relay) {
+  public Server(final Uuid id, final byte[] secret, final Relay relay) {
 
     this.id = id;
     this.secret = Arrays.copyOf(secret, secret.length);


### PR DESCRIPTION
When compiled with Java8 there were no errors but when compiled
with Java7 there were compile errors about missing final statements
for variable use inside an inner-class.