### PR TITLE
Added Optional Param for Relay Address

### DIFF
--- a/run_server.sh
+++ b/run_server.sh
@@ -17,11 +17,23 @@
 TEAM_ID="$1"
 TEAM_SECRET="$2"
 PORT="$3"
+RELAY_ADDRESS="$4"
 
 if [[ "TEAM_ID" == "" || "$TEAM_SECRET" == "" || "$PORT" == "" ]] ; then
-  echo 'usage: <TEAM ID> <TEAM SECRET> <PORT>'
+  echo 'usage: <TEAM ID> <TEAM SECRET> <PORT> [RELAY ADDRESS]'
   exit 1
 fi
 
 cd './bin'
-java codeu.chat.ServerMain "$TEAM_ID" "$TEAM_SECRET" "$PORT"
+if [ "$RELAY_ADDRESS" == "" ] ; then
+  java codeu.chat.ServerMain \
+      "$TEAM_ID" \
+      "$TEAM_SECRET" \
+      "$PORT"
+else
+  java codeu.chat.ServerMain \
+      "$TEAM_ID" \
+      "$TEAM_SECRET" \
+      "$PORT" \
+      "$RELAY_ADDRESS"
+fi


### PR DESCRIPTION
The java code supports an optional relay address but it was never passed through. This change adds support to the run_server script to pass through an optional relay address.