### PR TITLE
Fix Blank Line Fail in Teams File

### DIFF
--- a/src/codeu/chat/RelayMain.java
+++ b/src/codeu/chat/RelayMain.java
@@ -114,7 +114,9 @@ final class RelayMain {
 
         line = line.trim();
 
-        if (line.startsWith("#")) {
+        if (line.length() == 0) {
+          // This line is blank, skip it
+        } else if (line.startsWith("#")) {
           // this is a comment, skip it
         } else {
 


### PR DESCRIPTION
When the relay loads team data it tries to parse an empty string. It should just skip empty strings.

Closes #31