### PR TITLE
Relay re-load teams file

### DIFF
--- a/src/codeu/chat/RelayMain.java
+++ b/src/codeu/chat/RelayMain.java
@@ -63,7 +63,9 @@ final class RelayMain {
     }
   }
 
-  private static void startRelay(Server relay, ConnectionSource source, String teamFile) {
+  private static void startRelay(final Server relay,
+                                 final ConnectionSource source,
+                                 final String teamFile) {
 
     final ServerFrontEnd frontEnd = new ServerFrontEnd(relay);
     LOG.info("Relay front end object created.");

--- a/src/codeu/chat/RelayMain.java
+++ b/src/codeu/chat/RelayMain.java
@@ -80,8 +80,8 @@ final class RelayMain {
         loadTeamInfo(relay, teamFile);
         LOG.info("Done loading team data.");
 
-        // Add this again in 1 minute so that new entries to the time line will
-        // be added. This won't support updating entries.
+        // Add this again in 1 minute so that new team entries will be added to
+        // the relay. This won't support updating entries.
         timeline.scheduleIn(60000, this);
       }
     });

--- a/src/codeu/chat/RelayMain.java
+++ b/src/codeu/chat/RelayMain.java
@@ -54,28 +54,35 @@ final class RelayMain {
 
       LOG.info("Relay object created.");
 
-      LOG.info("Loading team data...");
-
-      loadTeamInfo(relay, args[1]);
-
-      LOG.info("Done loading team data.");
-
       LOG.info("Starting relay...");
 
-      startRelay(relay, source);
+      startRelay(relay, source, args[1]);
 
     } catch (IOException ex) {
       LOG.error(ex, "Failed to establish server accept port");
     }
   }
 
-  private static void startRelay(Server relay, ConnectionSource source) {
+  private static void startRelay(Server relay, ConnectionSource source, String teamFile) {
 
     final ServerFrontEnd frontEnd = new ServerFrontEnd(relay);
     LOG.info("Relay front end object created.");
 
     final Timeline timeline = new Timeline();
     LOG.info("Relay timeline created.");
+
+    timeline.scheduleNow(new Runnable() {
+      @Override
+      public void run() {
+        LOG.info("Loading team data...");
+        loadTeamInfo(relay, teamFile);
+        LOG.info("Done loading team data.");
+
+        // Add this again in 1 minute so that new entries to the time line will
+        // be added. This won't support updating entries.
+        timeline.scheduleIn(60000, this);
+      }
+    });
 
     LOG.info("Starting relay main loop...");
 


### PR DESCRIPTION
Before the relay would only read the teams file at the start-up. This meant that the relay would have to be restarted whenever a new team was added.

This change makes the relay reload the teams file every minute so that if a new team is added, they will have access within a minute. This will prevent the relay having to be taken down and losing all its data each time a new team comes on line.