### PR TITLE
Update Java JDK in Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: java
 sudo: false
 
 jdk:
-  - openjdk7
-  - oraclejdk8
+  - openjdk8
 
 os:
   - linux


### PR DESCRIPTION
The versions of java that Travis supports appears to have changed and we need to update our entries.